### PR TITLE
Fix yet another PHP 8 warning

### DIFF
--- a/inc/plugins/google_seo.php
+++ b/inc/plugins/google_seo.php
@@ -282,6 +282,8 @@ function google_seo_dynamic($url)
             }
         }
     }
+
+    return '';
 }
 
 /*


### PR DESCRIPTION
Explicitly return an empty string from `google_seo_dynamic()` at end of function, so that we don't get warnings from client functions expecting a string but instead getting null as the implicit return.