### PR TITLE
Fix another PHP 8 warning

### DIFF
--- a/inc/plugins/google_seo.php
+++ b/inc/plugins/google_seo.php
@@ -209,7 +209,7 @@ function google_seo_tid($pid, $tid=0, $mode='default', $limit=1)
             $tid = (int)$style['tid'];
         }
 
-        else if(is_array($thread) && $thread['firstpost'] == $pid && $thread['tid'] > 0)
+        else if(isset($thread['firstpost']) && $thread['firstpost'] == $pid && $thread['tid'] > 0)
         {
             $tid = (int)$thread['tid'];
         }


### PR DESCRIPTION
This one is a little quirky: when searching and showing results by post, the global variable `$thread` gets set in `search.php` on what at time of writing is line 261, but as an array containing only one element, `'tid'`, such that when via a series of function calls the line of code modified in this commit runs, `$thread` is indeed an array (which it shouldn't be, because it was set as a global variable only incidentally back in `search.php`), but doesn't contain the `'firstpost'` key.